### PR TITLE
moved from actix-ws to tokio-tungstenite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,6 @@ lto = true
 codegen-units = 1
 
 [workspace.dependencies]
-actix-web = { version = "4.9.0", features = ["rustls-0_23"] }
-actix-ws = "0.3.0"
 sqlx = { version = "0.8.2", features = [
     "sqlx-postgres",
     "postgres",
@@ -34,3 +32,5 @@ actix = "0.13.5"
 rustls-pemfile = "2.2.0"
 rustls = "0.23"
 dashmap = { version = "6.1.0", features = ["inline"] }
+tokio-tungstenite = "0.26.2"
+tokio = {version = "1.45.1", features = ["full"]}

--- a/infrastructure/Cargo.toml
+++ b/infrastructure/Cargo.toml
@@ -10,10 +10,11 @@ traits = { path = "../traits" }
 use_case = { path = "../use_case" }
 
 anyhow.workspace = true
-actix-ws.workspace = true
 serde_json.workspace = true
 futures.workspace = true
 log.workspace = true
 base64.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true
+tokio-tungstenite.workspace = true
+tokio.workspace = true

--- a/infrastructure/src/websocket.rs
+++ b/infrastructure/src/websocket.rs
@@ -1,4 +1,4 @@
-use actix_ws::Message;
+use tokio_tungstenite::tungstenite::Message;
 use futures::StreamExt;
 use log::debug;
 use std::{ops::ControlFlow, sync::Arc};
@@ -63,11 +63,9 @@ impl<MR: MessagesRepository + Clone, DB: MessagesDB + Clone> WebSocketService<MR
     /// # Arguments
     ///
     /// * `connection` - The WebSocket connection to handle
-    /// * `stream` - The message stream from the WebSocket connection
     pub async fn handle_connection(
         &self,
-        connection: WebSocketConnection,
-        mut stream: actix_ws::MessageStream,
+        connection: WebSocketConnection
     ) {
         let connection = Arc::new(connection);
         let manager = self.manager.clone();
@@ -80,6 +78,8 @@ impl<MR: MessagesRepository + Clone, DB: MessagesDB + Clone> WebSocketService<MR
             "Starting to handle websocket messages for connection: {}",
             connection.id
         );
+        
+        let mut stream = connection.session.lock().await;
 
         // Process each message in the stream until connection closes
         while let Some(Ok(msg)) = stream.next().await {

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -16,7 +16,8 @@ infrastructure = { path = "../infrastructure" }
 use_case = { path = "../use_case" }
 misc = { path = "../misc" }
 
-actix-web.workspace = true
 anyhow.workspace = true
 pretty_env_logger.workspace = true
 log.workspace = true
+tokio.workspace = true
+tokio-tungstenite.workspace = true

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -11,11 +11,11 @@ path = "src/lib.rs"
 thiserror.workspace = true
 serde.workspace = true
 dashmap.workspace = true
-actix-ws.workspace = true
 futures.workspace = true
-actix-web.workspace = true
 uuid.workspace = true
 flume.workspace = true
+tokio-tungstenite.workspace = true
+tokio.workspace = true  
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/use_case/Cargo.toml
+++ b/use_case/Cargo.toml
@@ -13,3 +13,4 @@ log.workspace = true
 flume.workspace = true
 futures.workspace = true
 serde_json.workspace = true
+tokio-tungstenite.workspace = true

--- a/use_case/src/messages.rs
+++ b/use_case/src/messages.rs
@@ -2,8 +2,10 @@ use std::sync::Arc;
 
 use anyhow::Result;
 
+use futures::SinkExt;
 use misc::base64::decode_base64;
 
+use tokio_tungstenite::tungstenite::Message;
 use traits::message::{MessagesDB, MessagesRepository};
 
 use protocol::entity::{
@@ -55,7 +57,11 @@ impl<T: MessagesDB> MessagesRepository for MessagesUseCase<T> {
 
         let mut session = connection.session.lock().await;
 
-        session.text(serde_json::to_string(&outgoing)?).await?;
+        let message = serde_json::to_string(&outgoing)?;
+        let message = Message::Text(message.into());
+
+        session.send(message).await?;
+        
         Ok(())
     }
 
@@ -78,7 +84,10 @@ impl<T: MessagesDB> MessagesRepository for MessagesUseCase<T> {
 
         let mut session = connection.session.lock().await;
 
-        session.text(serde_json::to_string(&outgoing)?).await?;
+        let message = serde_json::to_string(&outgoing)?;
+        let message = Message::Text(message.into());
+
+        session.send(message).await?;
 
         Ok(())
     }
@@ -99,7 +108,9 @@ impl<T: MessagesDB> MessagesRepository for MessagesUseCase<T> {
 
         let mut session = connection.session.lock().await;
 
-        session.text(serde_json::to_string(&outgoing)?).await?;
+        let message = serde_json::to_string(&outgoing)?;
+        let message = Message::Text(message.into());
+        session.send(message).await?;
 
         Ok(())
     }

--- a/use_case/src/websocket.rs
+++ b/use_case/src/websocket.rs
@@ -215,7 +215,13 @@ impl<T: MessagesRepository> WebsocketRepository for WebSocketUseCase<T> {
     /// * `connection` - Connection that is disconnecting
     async fn disconnect(&self, ws: Arc<WebSocketManager>, connection: Arc<WebSocketConnection>) {
         // Close the WebSocket session
-        let _ = connection.session.lock().await.to_owned().close(None).await;
+        let _ = connection
+            .session
+            .lock()
+            .await
+            .close(None)
+            .await
+            .map_err(|e| log::error!("Error closing WebSocket session: {}", e));
 
         // Unsubscribe from all chats this connection was subscribed to
         if let Some(chat_id) = ws.connections.get(&connection) {


### PR DESCRIPTION
The main reason behind moving from actix-ws to tokio-tungstenite was that actix-ws's connection struct didnt have Send + Sync implemented, therefore cannot be sent between threads. That ability imo was nesessary to add forwarding functionality and completely implement the protocol.

Also, as a side-effect, there is no need in actix-web server for now. The whole point of http server in the project was to initiate ws connection if user visit /ws.
Therefore I also got rid of actix-web in the project to tokio's raw TcpListener and TcpStream. That involved rewriting main() logic
